### PR TITLE
use bionic for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
-      - uses: docker://multiarch/debian-debootstrap:arm64-buster
+      - uses: docker://multiarch/ubuntu-core:arm64-bionic
         with:
           args: >
             bash -c
@@ -37,8 +37,8 @@ jobs:
             cd ./hyper &&
             sed -e '/},/{:a;N;/]/!ba};/        \"target\": \"snap\",/d' -i electron-builder.json &&
             sed -e '/          \"x64\",/d' -i electron-builder.json &&
-            yarn --network-timeout 1000000 &&
-            npm i app-builder-lib &&
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn --network-timeout 1000000 &&
+            npm i app-builder-lib --legacy-peer-deps &&
             USE_SYSTEM_FPM=true yarn run dist --publish=never &&
             mkdir -p ../pkgs &&
             mv ./dist/*.deb ../pkgs &&
@@ -87,8 +87,8 @@ jobs:
             sed -e '/},/{:a;N;/]/!ba};/        \"target\": \"snap\",/d' -i electron-builder.json &&
             sed -e '/          \"x64\",/d' -i electron-builder.json &&
             sed -e 's/          \"arm64\"/          \"armv7l\"/g' -i electron-builder.json &&
-            yarn --network-timeout 1000000 &&
-            npm i app-builder-lib &&
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn --network-timeout 1000000 &&
+            npm i app-builder-lib --legacy-peer-deps &&
             USE_SYSTEM_FPM=true yarn run dist --publish=never &&
             mkdir -p ../pkgs &&
             mv ./dist/*.deb ../pkgs &&


### PR DESCRIPTION
closes https://github.com/Jai-JAP/hyper-arm-builds/issues/3

see successful action here: https://github.com/theofficialgman/hyper-arm-builds/actions/runs/2489830112
see my releaes here: https://github.com/theofficialgman/hyper-arm-builds/releases/tag/v3.2.3

also you should keep in mind that upstream moved to electron 19.0.3. no new release yet, but depending on when they make a new release, the fixed electron 19.0.5 might not be out yet.

arm64 debs tested and working